### PR TITLE
Fix bonnie++ test

### DIFF
--- a/test/integration/default/bats/bonnie++.bats
+++ b/test/integration/default/bats/bonnie++.bats
@@ -6,6 +6,6 @@
 }
 
 @test "bonnie++ executes" {
-  run bonnie -s0
+  run bonnie -s0 -u root
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
When run as root, bonnie requires '-u'
